### PR TITLE
Change field data type

### DIFF
--- a/src/main/java/us/timinc/interactions/recipe/InteractRecipe.java
+++ b/src/main/java/us/timinc/interactions/recipe/InteractRecipe.java
@@ -57,7 +57,7 @@ public class InteractRecipe {
 	 */
 	public String damage = "";
 	/**
-	 * The chance (x in y represented as x:y) for the held item to be damaged.
+	 * The chance (expressed as a double between 0 and 1) for the held item to be damaged.
 	 */
 	public String damageChance = "";
 	/**


### PR DESCRIPTION
Wouldn't it make more sense to store a probability value like this as a double rather than a string? If it was stored that way, you could probably perform mathematical operations more easily.